### PR TITLE
Corrected the handling of the final flush to seq when a process exits. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ node your-app.js | pino-seq --serverUrl http://localhost:5341 --apiKey 123456789
 - `apiKey` - your Seq API key, if one is required; the default does not send an API key
 - `logOtherAs` - log other output (not formatted through pino) to seq at this loglevel. Useful to capture messages if the node process crashes or smilar.
 
+#### Capturing other output
+
+To enable capture of output not formatted through pino use the `logOtherAs` parameter. It's possible to use different settings for STDOUT/STDERR like this, when using bash:
+
+```shell
+node your-app.js 2> >(pino-seq --logOtherAs Error --serverUrl http://localhost:5341 --apiKey 1234567890) > >(pino-seq --logOtherAs Information --serverUrl http://localhost:5341 --apiKey 1234567890)
+```
+
 ### In-process (stream) usage
 
 Use the `createStream()` method to create a Pino stream configuration, passing `serverUrl`, `apiKey` and batching parameters.

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,6 @@ const split2 = require('split2');
 const pkg = require('./package.json');
 const pinoSeq = require('./index');
 
-
 function main() {
   program
     .version(pkg.version)
@@ -31,17 +30,16 @@ function main() {
 
         const handler = (err, name) => {
           writeStream.end(() => {
-            console.log("EXIT SIGNAL: " + name);
+            console.log('EXIT SIGNAL: ' + name);
             process.exit(0);
           });
-        }
+        };
 
-        process.on("SIGINT", () => handler(null, "SIGINT"));
-        process.on("SIGQUIT", () => handler(null, "SIGQUIT"));
-        process.on("SIGTERM", () => handler(null, "SIGTERM"));
-        process.on("SIGLOST", () => handler(null, "SIGLOST"))
-        process.on("SIGABRT", () => handler(null, "SIGABRT"))
-
+        process.on('SIGINT', () => handler(null, 'SIGINT'));
+        process.on('SIGQUIT', () => handler(null, 'SIGQUIT'));
+        process.on('SIGTERM', () => handler(null, 'SIGTERM'));
+        process.on('SIGLOST', () => handler(null, 'SIGLOST'));
+        process.on('SIGABRT', () => handler(null, 'SIGABRT'));
       } catch (error) {
         console.error(error);
       }

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ const split2 = require('split2');
 const pkg = require('./package.json');
 const pinoSeq = require('./index');
 
+
 function main() {
   program
     .version(pkg.version)
@@ -25,7 +26,22 @@ function main() {
     .action(({ serverUrl, apiKey, logOtherAs }) => {
       try {
         const writeStream = pinoSeq.createStream({ serverUrl, apiKey, logOtherAs });
+
         process.stdin.pipe(split2()).pipe(writeStream);
+
+        const handler = (err, name) => {
+          writeStream.end(() => {
+            console.log("EXIT SIGNAL: " + name);
+            process.exit(0);
+          });
+        }
+
+        process.on("SIGINT", () => handler(null, "SIGINT"));
+        process.on("SIGQUIT", () => handler(null, "SIGQUIT"));
+        process.on("SIGTERM", () => handler(null, "SIGTERM"));
+        process.on("SIGLOST", () => handler(null, "SIGLOST"))
+        process.on("SIGABRT", () => handler(null, "SIGABRT"))
+
       } catch (error) {
         console.error(error);
       }

--- a/cli.js
+++ b/cli.js
@@ -30,7 +30,6 @@ function main() {
 
         const handler = (err, name) => {
           writeStream.end(() => {
-            console.log('EXIT SIGNAL: ' + name);
             process.exit(0);
           });
         };

--- a/pinoSeqStream.js
+++ b/pinoSeqStream.js
@@ -88,7 +88,7 @@ class PinoSeqStream extends stream.Writable {
         this._logger.emit({
           timestamp: this._bufferTime,
           level: this._logOtherAs,
-          message: this._buffer.join('\n')
+          messageTemplate: this._buffer.join('\n')
         });
         this._bufferTime = false;
         this._buffer = [];
@@ -100,18 +100,12 @@ class PinoSeqStream extends stream.Writable {
 
   // Force the underlying logger to flush at the time of the call
   // and wait for pending writes to complete
-  _final() {
+  _final(callback) {
     this.flushBuffer();
-    return this._logger.flush();
-  }
-
-  // A browser only function that queues events for sending using the
-  // navigator.sendBeacon() API.  This may work in an unload or pagehide event
-  // handler when a normal flush() would not.
-  // Events over 63K in length are discarded (with a warning sent in its place)
-  // and the total size batch will be no more than 63K in length.
-  flushToBeacon() {
-    return this._logger.flushToBeacon();
+    this._logger
+      .close()
+      .then(() => callback())
+      .catch((err) => callback(err));
   }
 }
 


### PR DESCRIPTION
The CLI and stream won't close for until all messages has been flushed to SEQ. 

Removed the browser only method flushToBeacon, it had no place in a nodejs stream. 