### PR TITLE
Fixed cli stream error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ node your-app.js | pino-seq --serverUrl http://localhost:5341 --apiKey 123456789
 - `apiKey` - your Seq API key, if one is required; the default does not send an API key
 - `logOtherAs` - log other output (not formatted through pino) to seq at this loglevel. Useful to capture messages if the node process crashes or smilar.
 
+#### Capturing other output
+
+To enable capture of output not formatted through pino use the `logOtherAs` parameter. It's possible to use different settings for STDOUT/STDERR like this, when using bash:
+
+```shell
+node your-app.js 2> >(pino-seq --logOtherAs Error --serverUrl http://localhost:5341 --apiKey 1234567890) > >(pino-seq --logOtherAs Information --serverUrl http://localhost:5341 --apiKey 1234567890)
+```
+
 ### In-process (stream) usage
 
 Use the `createStream()` method to create a Pino stream configuration, passing `serverUrl`, `apiKey` and batching parameters.

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,7 @@ function main() {
       try {
         const writeStream = pinoSeq.createStream({ serverUrl, apiKey, logOtherAs });
 
-        process.stdin.pipe(split2()).pipe(writeStream);
+        process.stdin.pipe(split2()).pipe(writeStream).on("error", console.error);
 
         const handler = (err, name) => {
           writeStream.end(() => {

--- a/pinoSeqStream.js
+++ b/pinoSeqStream.js
@@ -33,7 +33,7 @@ class PinoSeqStream extends stream.Writable {
       try {
         let eventCopy = JSON.parse(message);
 
-        let { time, level, msg, exception, v, err, error, stack, ...props } = eventCopy;
+        let { time, level, msg, err, error, stack, ...props } = eventCopy;
 
         // Get the properties from the error
         let { message: errMessage, stack: errStack, ...errorProps } = err || error || {};


### PR DESCRIPTION
Errors from the seq stream is now handled by the cli (by console.log)
Re-added object params v, exception which was removed by mistake. 