### PR TITLE
bump to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-seq",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A stream that sends Pino log events to Seq",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumped a minor version as the behaviour changes - `onError` no longer destroys/crashes the PinoSeqStream when there is an error.