### PR TITLE
index.d.ts: Expose the flush method on the return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace PinoSeq {
     onError?: (e: Error) => void;
   }
 
-  function createStream(config: PinoSeq.SeqConfig): Writable & { _logger: seq.Logger; flush: () => void };
+  function createStream(config: PinoSeq.SeqConfig): Writable & { _logger: seq.Logger; flushBuffer: () => void };
   // Or perhaps just:
   // function createStream(config: PinoSeq.SeqConfig): Writable & { flush: () => void };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace PinoSeq {
 
   function createStream(config: PinoSeq.SeqConfig): Writable & { _logger: seq.Logger; flushBuffer: () => void };
   // Or perhaps just:
-  // function createStream(config: PinoSeq.SeqConfig): Writable & { flush: () => void };
+  // function createStream(config: PinoSeq.SeqConfig): Writable & { flushBuffer: () => void };
 }
 
 export = PinoSeq;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,9 @@ declare namespace PinoSeq {
     onError?: (e: Error) => void;
   }
 
-  function createStream(config: PinoSeq.SeqConfig): Writable;
+  function createStream(config: PinoSeq.SeqConfig): Writable & { _logger: seq.Logger; flush: () => void };
+  // Or perhaps just:
+  // function createStream(config: PinoSeq.SeqConfig): Writable & { flush: () => void };
 }
 
 export = PinoSeq;


### PR DESCRIPTION
AWS lambdas will halt/freeze the Node process as soon as a result is returned.
So, in order to not lose log entries, the lambda should flush logs just before returning a result