### PR TITLE
Fix pino-seq has no default export

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -1,12 +1,10 @@
-"use strict";
-
 import pino from 'pino';
 import pinoToSeq from '../index.js';
 
-let stream = pinoToSeq.createStream({serverUrl: "http://localhost:5341"});
-let logger = pino({name: "pino-seq example"}, stream);
+let stream = pinoToSeq.createStream({ serverUrl: 'http://localhost:5341' });
+let logger = pino({ name: 'pino-seq example' }, stream);
 
-logger.info("Hello Seq, from Pino");
+logger.info('Hello Seq, from Pino');
 
-let frLogger = logger.child({lang: "fr"});
-frLogger.warn("au reviour");
+let frLogger = logger.child({ lang: 'fr' });
+frLogger.warn('au reviour');

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,16 +1,16 @@
-import Pino from "pino"
-import PinoSeq from ".."
+import { pino, type LoggerOptions } from 'pino';
+import PinoSeq from '../index.js';
 
-const stream = PinoSeq.createStream({serverUrl: "http://localhost:5341"});
+const stream = PinoSeq.createStream({ serverUrl: 'http://localhost:5341' });
 
-const options: Pino.LoggerOptions = {
-  name: "pino-seq example"
-}
-const logger: Pino.Logger = Pino(options, stream);
+const options: LoggerOptions = {
+  name: 'pino-seq example'
+};
+const logger = pino(options, stream);
 
-logger.info("Hello Seq, from Pino");
+logger.info('Hello Seq, from Pino');
 
-const frLogger = logger.child({lang: "fr"});
-frLogger.warn("au reviour");
+const frLogger = logger.child({ lang: 'fr' });
+frLogger.warn('au reviour');
 
-stream.flush().then((_) => console.log('flushed'));
+stream.flush().then(() => console.log('flushed'));

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Writable } from 'stream';
+import { Writable } from 'node:stream';
 
 declare namespace PinoSeq {
   interface SeqConfig {
@@ -16,4 +16,4 @@ declare namespace PinoSeq {
   };
 }
 
-export = PinoSeq;
+export { PinoSeq as default };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-"use strict";
-
 import { PinoSeqStream } from './pinoSeqStream.js';
 
 export default {
-  createStream: config => {
+  createStream: (config) => {
     config = config || {};
     return new PinoSeqStream(config);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pino-seq",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pino-seq",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",
@@ -17,6 +17,8 @@
         "pino-seq": "cli.js"
       },
       "devDependencies": {
+        "@tsconfig/node18": "^18.2.4",
+        "@types/node": "^18.19.111",
         "mocha": "^11.2.2",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3"
@@ -453,6 +455,23 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.111",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
+      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/abort-controller": {
@@ -1595,6 +1614,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "type": "module",
   "scripts": {
-    "test": "mocha",
+    "check": "tsc --noEmit",
+    "test": "npm run check && mocha",
     "start": "node ./example/example.js",
     "start:ts": "tsx ./example/example.ts"
   },
@@ -28,6 +29,8 @@
   },
   "homepage": "https://github.com/datalust/pino-seq#readme",
   "devDependencies": {
+    "@tsconfig/node18": "^18.2.4",
+    "@types/node": "^18.19.111",
     "mocha": "^11.2.2",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"

--- a/pinoSeqStream.js
+++ b/pinoSeqStream.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import stream from 'stream';
 import { Logger as SeqLogger } from 'seq-logging';
 
@@ -17,7 +15,11 @@ class PinoSeqStream extends stream.Writable {
     super();
 
     let { additionalProperties, logOtherAs, ...loggerConfig } = config == null ? {} : { ...config };
-    loggerConfig.onError = loggerConfig.onError || function (e) { console.error('[PinoSeqStream] Log batch failed\n', e) };
+    loggerConfig.onError =
+      loggerConfig.onError ||
+      function (e) {
+        console.error('[PinoSeqStream] Log batch failed\n', e);
+      };
     this._additionalProperties = additionalProperties;
     this._logOtherAs = logOtherAs;
     this._bufferTime = false;
@@ -88,7 +90,7 @@ class PinoSeqStream extends stream.Writable {
           timestamp: this._bufferTime,
           level: this._logOtherAs,
           messageTemplate: this._buffer.join('\n'),
-          properties: { ...this._additionalProperties },
+          properties: { ...this._additionalProperties }
         });
         this._bufferTime = false;
         this._buffer = [];

--- a/test/pinoSeqSteam_tests.js
+++ b/test/pinoSeqSteam_tests.js
@@ -1,11 +1,9 @@
-"use strict";
-
 import { PinoSeqStream } from '../pinoSeqStream.js';
 
 describe('PinoSeqStream', () => {
-   describe('constructor', () => {
-       it('can be constructed', () => {
-          new PinoSeqStream(); 
-       });
-   });
+  describe('constructor', () => {
+    it('can be constructed', () => {
+      new PinoSeqStream();
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json"
+}


### PR DESCRIPTION

This PR contains a fix for the TS "no default export" error.

- I added a `tsconfig.json` file based on the `@tsconfig/node18` configuration and a npm `check` task.
- Added the default export.
- Bonus: removed `'use strict'` because [ES Modules are automatically](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules) in strict mode.

this closes #45.