### PR TITLE
Fix type for flush promise return value: Boolean -> boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace PinoSeq {
   }
 
   function createStream(config: PinoSeq.SeqConfig): Writable & {
-    flush: () => Promise<Boolean>;
+    flush: () => Promise<boolean>;
   };
 }
 


### PR DESCRIPTION
In TypeScript, there is a crucial distinction between boolean (lowercase) and Boolean (uppercase).

boolean (lowercase): This refers to the primitive boolean type in TypeScript and JavaScript. It represents a simple true or false value. This is the type that should be used almost exclusively when declaring variables, function parameters, or return types in TypeScript.

Boolean (uppercase): This refers to the JavaScript Boolean object wrapper. While it can also hold a true or false value, it is an object, not a primitive. Using Boolean objects can lead to unexpected behavior due to JavaScript's type coercion rules, where an object (even a Boolean object wrapping false) is considered "truthy" in a boolean context.